### PR TITLE
Improvements: Buffers as input, types, whitespace fixes

### DIFF
--- a/src/mergeDocx.ts
+++ b/src/mergeDocx.ts
@@ -1,15 +1,16 @@
-import { XMLParser, XMLBuilder } from 'fast-xml-parser';
+import { XMLParser, XMLBuilder, type X2jOptions, type XmlBuilderOptions } from 'fast-xml-parser';
 import AdmZip from 'adm-zip';
 import fs from 'fs';
 
 const documentXMLPath = 'word/document.xml';
 
 const parseXML = (xmlString: string) => {
-  const options = {
+  const options: X2jOptions = {
     allowBooleanAttributes: true,
     attributeNamePrefix: '@_',
     ignoreAttributes: false,
     preserveOrder: true,
+    trimValues: false,
   };
   const parser = new XMLParser(options);
   return parser.parse(xmlString);
@@ -17,7 +18,7 @@ const parseXML = (xmlString: string) => {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const buildXML = (xmlObject: any) => {
-  const options = {
+  const options: XmlBuilderOptions = {
     attributeNamePrefix: '@_',
     format: true,
     ignoreAttributes: false,

--- a/src/mergeDocx.ts
+++ b/src/mergeDocx.ts
@@ -220,5 +220,6 @@ export const mergeDocx = (
     return newZip.toBuffer();
   }
 
-  return newZip.writeZip(outputPath);
+  newZip.writeZip(outputPath);
+  return undefined;
 };

--- a/src/mergeDocx.ts
+++ b/src/mergeDocx.ts
@@ -151,8 +151,8 @@ const getXmlBody = (xmlArray: any) => {
 };
 
 export const mergeDocx = (
-  sourcePath: string,
-  contentPath: string,
+  sourcePathOrBuffer: string | Buffer,
+  contentPathOrBuffer: string | Buffer,
   {
     outputPath,
     pattern,
@@ -165,12 +165,12 @@ export const mergeDocx = (
     insertEnd?: boolean;
   },
 ) => {
-  if (!sourcePath || !contentPath) {
+  if (!sourcePathOrBuffer || !contentPathOrBuffer) {
     throw new Error('Missing source or content path');
   }
   if (
-    !sourcePath.endsWith('.docx') ||
-    !contentPath.endsWith('.docx') ||
+    (typeof sourcePathOrBuffer === 'string' && !sourcePathOrBuffer.endsWith('.docx')) ||
+    (typeof contentPathOrBuffer === 'string' && !contentPathOrBuffer.endsWith('.docx')) ||
     (outputPath && !outputPath.endsWith('.docx'))
   ) {
     throw new Error('Invalid file extension. Only .docx files are supported');
@@ -180,25 +180,25 @@ export const mergeDocx = (
     throw new Error("At least one of 'pattern', 'insertStart', or 'insertEnd' must be provided.");
   }
 
-  if (!fs.existsSync(sourcePath)) {
-    throw new Error(`Source file does not exist: ${sourcePath}`);
+  if (typeof sourcePathOrBuffer === 'string' && !fs.existsSync(sourcePathOrBuffer)) {
+    throw new Error(`Source file does not exist: ${sourcePathOrBuffer}`);
   }
-  if (!fs.existsSync(contentPath)) {
-    throw new Error(`Content file does not exist: ${contentPath}`);
+  if (typeof contentPathOrBuffer === 'string' && !fs.existsSync(contentPathOrBuffer)) {
+    throw new Error(`Content file does not exist: ${contentPathOrBuffer}`);
   }
 
-  const zip = new AdmZip(sourcePath);
+  const zip = new AdmZip(sourcePathOrBuffer);
 
   const templateXML = zip.readAsText(documentXMLPath, 'utf8');
   if (!templateXML) {
-    throw new Error(`Entry ${documentXMLPath} not found in ${sourcePath}`);
+    throw new Error(`Entry ${documentXMLPath} not found in ${sourcePathOrBuffer}`);
   }
 
-  const contentZip = new AdmZip(contentPath);
+  const contentZip = new AdmZip(contentPathOrBuffer);
 
   const contentXML = contentZip.readAsText(documentXMLPath, 'utf8');
   if (!contentXML) {
-    throw new Error(`Entry ${documentXMLPath} not found in ${contentPath}`);
+    throw new Error(`Entry ${documentXMLPath} not found in ${contentPathOrBuffer}`);
   }
 
   const templateParsedXML = parseXML(templateXML);

--- a/tests/mergeDocx.test.ts
+++ b/tests/mergeDocx.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { mergeDocx } from '../src/index';
-import { existsSync, unlinkSync } from 'fs';
+import { existsSync, readFileSync, unlinkSync } from 'fs';
 
 describe('mergeDocx', () => {
   it('merges two DOCX files and creates output file', () => {
@@ -20,6 +20,16 @@ describe('mergeDocx', () => {
   it('merges two DOCX files and returns buffer', () => {
     const file1 = './tests/fixtures/template.docx';
     const file2 = './tests/fixtures/table.docx';
+
+    const buffer = mergeDocx(file1, file2, { pattern: '{{table}}' });
+
+    // Check if the buffer is not empty
+    expect(buffer).toBeInstanceOf(Buffer);
+  });
+
+  it('merges two DOCX buffers and returns buffer', () => {
+    const file1 = readFileSync('./tests/fixtures/template.docx');
+    const file2 = readFileSync('./tests/fixtures/table.docx');
 
     const buffer = mergeDocx(file1, file2, { pattern: '{{table}}' });
 


### PR DESCRIPTION
Hello Benedicte,

I made some improvements and fixes to the library that I needed for myself and I think are generally useful.

These are:

- Allowing the input documents to be passed in as Buffers. In my use case, I am generating documents on the fly and writing them to disc would be an unnecessary step.
-  Fixes an issue where due to the parsing of the input xml, whitespace may currently be removed from the input, depending on the structure of the document.
- A small change to the output type of the main `mergeDocx`-function. It is now `undefined` instead of `void`, which is easier to check for in code that calls the function.

Feel free to merge these changes if you find them useful. I can make separate PRs or create issues if needed.